### PR TITLE
unsafe impl `Send+Sync` for `Submitter`, `SubmissionQueue`, `CompletionQueue`

### DIFF
--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -168,6 +168,9 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     // regression test
     tests::regression::test_issue154(&mut ring, &test)?;
 
+    // api tests
+    tests::api::test_sendness(&mut ring, &test)?;
+
     println!("Test count: {}", test.count.get());
 
     Ok(())

--- a/io-uring-test/src/tests/api.rs
+++ b/io-uring-test/src/tests/api.rs
@@ -6,8 +6,13 @@ pub fn test_sendness<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     ring: &mut IoUring<S, C>,
     _test: &Test,
 ) -> anyhow::Result<()> {
+    fn assert_send<T: Send>(t: T) -> T {
+        t
+    }
+
+    let ring = assert_send(ring);
+
     let (submitter, sq, cq) = ring.split();
-    fn assert_send<T: Send>(_t: T) {}
     assert_send(submitter);
     assert_send(sq);
     assert_send(cq);

--- a/io-uring-test/src/tests/api.rs
+++ b/io-uring-test/src/tests/api.rs
@@ -1,0 +1,15 @@
+use crate::Test;
+use io_uring::IoUring;
+use io_uring::{cqueue, squeue};
+
+pub fn test_sendness<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
+    let (submitter, sq, cq) = ring.split();
+    fn assert_send<T: Send>(_t: T) {}
+    assert_send(submitter);
+    assert_send(sq);
+    assert_send(cq);
+    Ok(())
+}

--- a/io-uring-test/src/tests/api.rs
+++ b/io-uring-test/src/tests/api.rs
@@ -4,7 +4,7 @@ use io_uring::{cqueue, squeue};
 
 pub fn test_sendness<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     ring: &mut IoUring<S, C>,
-    test: &Test,
+    _test: &Test,
 ) -> anyhow::Result<()> {
     let (submitter, sq, cq) = ring.split();
     fn assert_send<T: Send>(_t: T) {}

--- a/io-uring-test/src/tests/mod.rs
+++ b/io-uring-test/src/tests/mod.rs
@@ -1,3 +1,4 @@
+pub mod api;
 pub mod cancel;
 pub mod fs;
 pub mod futex;

--- a/src/cqueue.rs
+++ b/src/cqueue.rs
@@ -22,6 +22,9 @@ pub(crate) struct Inner<E: EntryMarker> {
     flags: *const atomic::AtomicU32,
 }
 
+/// SAFETY: there isn't anything thread-local about the completion queue;
+unsafe impl<E: EntryMarker> Send for Inner<E> {}
+
 /// An io_uring instance's completion queue. This stores all the I/O operations that have completed.
 pub struct CompletionQueue<'a, E: EntryMarker = Entry> {
     head: u32,
@@ -32,7 +35,7 @@ pub struct CompletionQueue<'a, E: EntryMarker = Entry> {
 /// A completion queue entry (CQE), representing a complete I/O operation.
 ///
 /// This is implemented for [`Entry`] and [`Entry32`].
-pub trait EntryMarker: Clone + Debug + Into<Entry> + private::Sealed {
+pub trait EntryMarker: Send + Clone + Debug + Into<Entry> + private::Sealed {
     const BUILD_FLAGS: u32;
 }
 

--- a/src/cqueue.rs
+++ b/src/cqueue.rs
@@ -23,6 +23,7 @@ pub(crate) struct Inner<E: EntryMarker> {
 }
 
 /// SAFETY: there isn't anything thread-local about the completion queue;
+unsafe impl<E: EntryMarker> Sync for Inner<E> {}
 unsafe impl<E: EntryMarker> Send for Inner<E> {}
 
 /// An io_uring instance's completion queue. This stores all the I/O operations that have completed.

--- a/src/cqueue.rs
+++ b/src/cqueue.rs
@@ -31,10 +31,6 @@ pub struct CompletionQueue<'a, E: EntryMarker = Entry> {
 
 /// SAFETY: there isn't anything thread-local about the completion queue memory;
 unsafe impl<'a, E: EntryMarker> Send for CompletionQueue<'a, E> {}
-/// SAFETY: the methods that mutate state are all `&mut self`, thereby eliminating
-/// data races at compile time via the standard borrowing rules.
-/// (There are `unsafe` methods like `borrow_shared()` that allow violating this.)
-unsafe impl<'a, E: EntryMarker> Sync for CompletionQueue<'a, E> {}
 
 /// A completion queue entry (CQE), representing a complete I/O operation.
 ///

--- a/src/cqueue.rs
+++ b/src/cqueue.rs
@@ -31,6 +31,13 @@ pub struct CompletionQueue<'a, E: EntryMarker = Entry> {
 
 /// SAFETY: there isn't anything thread-local about the completion queue memory;
 unsafe impl<'a, E: EntryMarker> Send for CompletionQueue<'a, E> {}
+/// SAFETY: mutating methods take `&mut self`, thereby eliminating data races between
+/// different userspace borrowers at compile time via standard borrowing rules.
+/// (There are `unsafe` methods like `borrow_shared()` that allow violating this.)
+///
+/// The various pointers to atomics are pointers to shared state between
+/// userspace and kernel, and orthogonal to this unsafe impl.
+unsafe impl<'a, E: EntryMarker> Sync for CompletionQueue<'a, E> {}
 
 /// A completion queue entry (CQE), representing a complete I/O operation.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,15 +72,6 @@ pub struct Parameters(sys::io_uring_params);
 /// SAFETY: there isn't anything thread-local about an io_uring instance.
 /// (We do not attempt to model `IORING_SETUP_SINGLE_ISSUER` in the type system.)
 unsafe impl<S: squeue::EntryMarker, C: cqueue::EntryMarker> Send for IoUring<S, C> {}
-/// SAFETY: the methods that allow mutating the userspace-owned ranges of memory in the ring
-/// mutate state are all `&mut self`, thereby eliminating
-/// data races at compile time via the standard borrowing rules.
-/// (There are `unsafe` methods like `submission_shared()` that allow violating this.)
-///
-/// Note that we allow for concurrent calls to `submit()`, resulting in weird
-/// brings a bunch of ToC ToU headache.
-///
-unsafe impl<S: squeue::EntryMarker, C: cqueue::EntryMarker> Sync for IoUring<S, C> {}
 
 impl IoUring<squeue::Entry, cqueue::Entry> {
     /// Create a new `IoUring` instance with default configuration parameters. See [`Builder`] to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,11 @@ pub struct Parameters(sys::io_uring_params);
 /// SAFETY: there isn't anything thread-local about an io_uring instance.
 /// (We do not attempt to model `IORING_SETUP_SINGLE_ISSUER` in the type system.)
 unsafe impl<S: squeue::EntryMarker, C: cqueue::EntryMarker> Send for IoUring<S, C> {}
+/// SAFETY: mutating methods take `&mut self`, thereby eliminating data races between
+/// different userspace borrowers at compile time via standard borrowing rules.
+/// (There are `unsafe` methods like `submission_shared()` and `completion_shared()`
+///  that allow violating this.)
+unsafe impl<S: squeue::EntryMarker, C: cqueue::EntryMarker> Sync for IoUring<S, C> {}
 
 impl IoUring<squeue::Entry, cqueue::Entry> {
     /// Create a new `IoUring` instance with default configuration parameters. See [`Builder`] to

--- a/src/squeue.rs
+++ b/src/squeue.rs
@@ -24,6 +24,7 @@ pub(crate) struct Inner<E: EntryMarker> {
 /// SAFETY: there isn't anything thread-local about the submission queue;
 /// There is IORING_SETUP_SINGLE_ISSUER, but that only poses limitations on
 /// where the [`super::submit::Submitter`] may be used, not the [`SubmissionQueue`].
+unsafe impl<E: EntryMarker> Sync for Inner<E> {}
 unsafe impl<E: EntryMarker> Send for Inner<E> {}
 
 /// An io_uring instance's submission queue. This is used to send I/O requests to the kernel.

--- a/src/squeue.rs
+++ b/src/squeue.rs
@@ -21,6 +21,11 @@ pub(crate) struct Inner<E: EntryMarker> {
     pub(crate) sqes: *mut E,
 }
 
+/// SAFETY: there isn't anything thread-local about the submission queue;
+/// There is IORING_SETUP_SINGLE_ISSUER, but that only poses limitations on
+/// where the [`super::submit::Submitter`] may be used, not the [`SubmissionQueue`].
+unsafe impl<E: EntryMarker> Send for Inner<E> {}
+
 /// An io_uring instance's submission queue. This is used to send I/O requests to the kernel.
 pub struct SubmissionQueue<'a, E: EntryMarker = Entry> {
     head: u32,
@@ -31,7 +36,7 @@ pub struct SubmissionQueue<'a, E: EntryMarker = Entry> {
 /// A submission queue entry (SQE), representing a request for an I/O operation.
 ///
 /// This is implemented for [`Entry`] and [`Entry128`].
-pub trait EntryMarker: Clone + Debug + From<Entry> + private::Sealed {
+pub trait EntryMarker: Send + Clone + Debug + From<Entry> + private::Sealed {
     const BUILD_FLAGS: u32;
 }
 

--- a/src/squeue.rs
+++ b/src/squeue.rs
@@ -29,13 +29,8 @@ pub struct SubmissionQueue<'a, E: EntryMarker = Entry> {
 }
 
 /// SAFETY: there isn't anything thread-local about the submission queue;
-/// There is `IORING_SETUP_SINGLE_ISSUER`, but that only poses limitations on
-/// where the [`super::submit::Submitter`] may be used, not the [`SubmissionQueue`].
+/// (We do not attempt to model `IORING_SETUP_SINGLE_ISSUER` in the type system.)
 unsafe impl<'a, E: EntryMarker> Send for SubmissionQueue<'a, E> {}
-/// SAFETY: the methods that mutate state are all `&mut self`, thereby eliminating
-/// data races at compile time via the standard borrowing rules.
-/// (There are `unsafe` methods like `borrow_shared()` that allow violating this.)
-unsafe impl<'a, E: EntryMarker> Sync for SubmissionQueue<'a, E> {}
 
 /// A submission queue entry (SQE), representing a request for an I/O operation.
 ///

--- a/src/squeue.rs
+++ b/src/squeue.rs
@@ -31,6 +31,13 @@ pub struct SubmissionQueue<'a, E: EntryMarker = Entry> {
 /// SAFETY: there isn't anything thread-local about the submission queue;
 /// (We do not attempt to model `IORING_SETUP_SINGLE_ISSUER` in the type system.)
 unsafe impl<'a, E: EntryMarker> Send for SubmissionQueue<'a, E> {}
+/// SAFETY: mutating methods take `&mut self`, thereby eliminating data races between
+/// different userspace borrowers at compile time via standard borrowing rules.
+/// (There are `unsafe` methods like `borrow_shared()` that allow violating this.)
+///
+/// The various pointers to atomics are pointers to shared state between
+/// userspace and kernel, and orthogonal to this unsafe impl.
+unsafe impl<'a, E: EntryMarker> Sync for SubmissionQueue<'a, E> {}
 
 /// A submission queue entry (SQE), representing a request for an I/O operation.
 ///

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -26,6 +26,14 @@ pub struct Submitter<'a> {
     sq_flags: *const atomic::AtomicU32,
 }
 
+/// SAFETY: there isn't anyhting thread-local about submission that would make Send memory unsafe.
+///
+/// There is IORING_SETUP_SINGLE_ISSUER, where !Send helps us turn what would be a runtime error
+/// into a compile-time error. But at this time, giving users flexibility is more important to us.
+/// TODO: use typestate pattern to track whether IORING_SETUP_SINGLE_ISSUER is set, and make this
+/// unsafe impl conditional on it not being set.
+unsafe impl<'a> Send for Submitter<'a> {}
+
 impl<'a> Submitter<'a> {
     #[inline]
     pub(crate) const fn new(

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -29,13 +29,6 @@ pub struct Submitter<'a> {
 /// SAFETY: there isn't anyhting thread-local about submission that would make Send memory unsafe.
 /// (We do not attempt to model `IORING_SETUP_SINGLE_ISSUER` in the type system.)
 unsafe impl<'a> Send for Submitter<'a> {}
-/// SAFETY: [`Submitter`] itself does not mutate anything, so it's memory-safe to mark it Sync.
-/// It is questionable  `io_uring_enter` concurrently against the same io_uring instance,
-///
-/// threads is safe to do.
-/// calls
-/// have defined semantics
-unsafe impl<'a> Sync for Submitter<'a> {}
 
 impl<'a> Submitter<'a> {
     #[inline]

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -27,13 +27,15 @@ pub struct Submitter<'a> {
 }
 
 /// SAFETY: there isn't anyhting thread-local about submission that would make Send memory unsafe.
-///
-/// There is IORING_SETUP_SINGLE_ISSUER, where !Send helps us turn what would be a runtime error
-/// into a compile-time error. But at this time, giving users flexibility is more important to us.
-/// TODO: use typestate pattern to track whether IORING_SETUP_SINGLE_ISSUER is set, and make this
-/// unsafe impl conditional on it not being set.
-unsafe impl<'a> Sync for Submitter<'a> {}
+/// (We do not attempt to model `IORING_SETUP_SINGLE_ISSUER` in the type system.)
 unsafe impl<'a> Send for Submitter<'a> {}
+/// SAFETY: [`Submitter`] itself does not mutate anything, so it's memory-safe to mark it Sync.
+/// It is questionable  `io_uring_enter` concurrently against the same io_uring instance,
+///
+/// threads is safe to do.
+/// calls
+/// have defined semantics
+unsafe impl<'a> Sync for Submitter<'a> {}
 
 impl<'a> Submitter<'a> {
     #[inline]

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -32,6 +32,7 @@ pub struct Submitter<'a> {
 /// into a compile-time error. But at this time, giving users flexibility is more important to us.
 /// TODO: use typestate pattern to track whether IORING_SETUP_SINGLE_ISSUER is set, and make this
 /// unsafe impl conditional on it not being set.
+unsafe impl<'a> Sync for Submitter<'a> {}
 unsafe impl<'a> Send for Submitter<'a> {}
 
 impl<'a> Submitter<'a> {

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -29,6 +29,9 @@ pub struct Submitter<'a> {
 /// SAFETY: there isn't anyhting thread-local about submission that would make Send memory unsafe.
 /// (We do not attempt to model `IORING_SETUP_SINGLE_ISSUER` in the type system.)
 unsafe impl<'a> Send for Submitter<'a> {}
+/// SAFETY: [`Submitter`] methods do not manipulate any state themselves (the kernel might do that,
+/// during io_uring_enter, but that's orthogonal to this unsafe impl).
+unsafe impl<'a> Sync for Submitter<'a> {}
 
 impl<'a> Submitter<'a> {
     #[inline]


### PR DESCRIPTION
The `IoUring` type already has `Send` + `Sync` impls.

In [tokio-epoll-uring](https://github.com/neondatabase/tokio-epoll-uring), we use `split()` and need the `Submitter`, `SubmissionQueue` and `CompletionQueue` to be `Send` (not sync, though).

This PR adds those `unsafe impl`s, and adds hopefully not too repetitive commentary on why these impls are safe.